### PR TITLE
enable to specify db number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased][unreleased]
 
+### Added
+- enabled to specify db number for the redis connection with `-d` option
+
 ## [0.0.2] - 2015-06-03
 
 ### Fixed

--- a/bin/metrics-resque.rb
+++ b/bin/metrics-resque.rb
@@ -45,6 +45,12 @@ class ResqueMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Redis port',
          default: '6379'
 
+  option :db,
+         short: '-d DB',
+         long: '--db DB',
+         description: 'Redis DB',
+         default: '0'
+
   option :namespace,
          description: 'Resque namespace',
          short: '-n NAMESPACE',
@@ -58,7 +64,7 @@ class ResqueMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{Socket.gethostname}.resque"
 
   def run
-    redis = Redis.new(host: config[:hostname], port: config[:port])
+    redis = Redis.new(host: config[:hostname], port: config[:port], db: config[:db])
     Resque.redis = redis
     Resque.redis.namespace = config[:namespace]
     count = Resque::Failure::Redis.count


### PR DESCRIPTION
Enabled to specify db number for redis connection.
This option is needed when storing queue data in a database other than db0.
